### PR TITLE
grantPermission Function

### DIFF
--- a/StockToken.sol
+++ b/StockToken.sol
@@ -42,10 +42,11 @@ contract StockToken {
         emit Transfer(msg.sender, receiver, numTokens);
         return true;
     }
-    
+
+    //changed msg.sender to tx.origin
     function approve(address delegate, uint numTokens) public returns (bool) {
-        allowed[msg.sender][delegate] = numTokens;
-        emit Approval(msg.sender, delegate, numTokens);
+        allowed[tx.origin][delegate] = numTokens;
+        emit Approval(tx.origin, delegate, numTokens);
         return true;
     }
 


### PR DESCRIPTION
added func on TokenTrader that allows user to grant the contract permission without having to leave the dapp.

NOTE: This did require moving away from erc-20 standard slightly by passing "tx.origin" instead of "msg.sender" in its allowed approve function.